### PR TITLE
Update libxdma.c

### DIFF
--- a/XDMA/linux-kernel/tools/Makefile
+++ b/XDMA/linux-kernel/tools/Makefile
@@ -1,24 +1,38 @@
+prefix := /usr/local
+bindir := $(prefix)/bin
+PROGRAM_PREFIX :=
 CC ?= gcc
+CFLAGS ?=
+LDFLAGS ?=
+EXTRA_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+INSTALL ?= install
 
-all: reg_rw dma_to_device dma_from_device performance test_chrdev
+PROGRAMS = $(PROGRAM_PREFIX)reg_rw $(PROGRAM_PREFIX)dma_to_device $(PROGRAM_PREFIX)dma_from_device $(PROGRAM_PREFIX)performance $(PROGRAM_PREFIX)test_chrdev
 
-dma_to_device: dma_to_device.o
-	$(CC) -lrt -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+all: $(PROGRAMS)
 
-dma_from_device: dma_from_device.o
-	$(CC) -lrt -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+$(PROGRAM_PREFIX)dma_to_device: dma_to_device.o
+	$(CC) -lrt -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
-performance: performance.o
-	$(CC) -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+$(PROGRAM_PREFIX)dma_from_device: dma_from_device.o
+	$(CC) -lrt -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
-reg_rw: reg_rw.o
-	$(CC) -o $@ $<
+$(PROGRAM_PREFIX)performance: performance.o
+	$(CC) -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
-test_chrdev: test_chrdev.o
-	$(CC) -o $@ $<
+$(PROGRAM_PREFIX)reg_rw: reg_rw.o
+	$(CC) -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
+
+$(PROGRAM_PREFIX)test_chrdev: test_chrdev.o
+	$(CC) -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
 %.o: %.c
-	$(CC) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) -c -std=c99 -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS)
 
 clean:
-	rm -rf reg_rw *.o *.bin dma_to_device dma_from_device performance test_chrdev
+	rm -rf *.o *.bin
+	rm -fr $(PROGRAMS)
+
+install: all
+	install -d -m 0755 "$(DESTDIR)$(bindir)"
+	install -m 0755 $(PROGRAMS) "$(DESTDIR)$(bindir)"

--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -33,8 +33,10 @@ ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o
 	obj-m := $(TARGET_MODULE).o
 else
-	BUILDSYSTEM_DIR:=/lib/modules/$(shell uname -r)/build
+	MODLIB:=/lib/modules/$(shell uname -r)
+	BUILDSYSTEM_DIR:=$(MODLIB)/build
 	PWD:=$(shell pwd)
+	DEPMOD:=depmod
 all :
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) modules
 
@@ -42,17 +44,19 @@ clean:
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) clean
 	@/bin/rm -f *.ko modules.order *.mod.c *.o *.o.ur-safe .*.o.cmd
 
-install: all
+install: modules_install
 	@rm -f /lib/modules/5.15.0-67-generic/extra/xdma.ko
-	@echo "installing kernel modules to /lib/modules/$(shell uname -r)/xdma ..."
-	@mkdir -p -m 755 /lib/modules/$(shell uname -r)/xdma
-	@install -v -m 644 *.ko /lib/modules/$(shell uname -r)/xdma
-	@depmod -a || true
+
+modules_install: all
+	@echo "installing kernel modules to $(MODLIB)/xdma ..."
+	@mkdir -p -m 755 $(MODLIB)/xdma
+	@install -v -m 644 *.ko $(MODLIB)/xdma
+	@$(DEPMOD) -a || true
 
 uninstall:
-	@echo "Un-installing /lib/modules/$(shell uname -r)/xdma ..."
-	@/bin/rm -rf /lib/modules/$(shell uname -r)/xdma
-	@depmod -a
+	@echo "Un-installing $(MODLIB)/xdma ..."
+	@/bin/rm -rf $(MODLIB)/xdma
+	@$(DEPMOD) -a || true
 
 
 

--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -18,7 +18,7 @@ $(warning XVC_FLAGS: $(XVC_FLAGS).)
 
 topdir := $(shell cd $(src)/.. && pwd)
 
-TARGET_MODULE:=xdma
+TARGET_MODULE:=xdma-chr
 
 EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
 ifeq ($(DEBUG),1)

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -194,9 +194,9 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	struct xdma_dev *xdev;
 	struct xdma_cdev *xcdev = (struct xdma_cdev *)file->private_data;
 	unsigned long off;
-	unsigned long phys;
+	resource_size_t phys;
 	unsigned long vsize;
-	unsigned long psize;
+	resource_size_t psize;
 	int rv;
 
 	rv = xcdev_check(__func__, xcdev, 0);

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -115,8 +115,13 @@ static long version_ioctl(struct xdma_cdev *xcdev, void __user *arg)
 	obj.subsystem_device = xdev->pdev->subsystem_device;
 	obj.feature_id = xdev->feature_id;
 	obj.driver_version = DRV_MOD_VERSION_NUMBER;
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 19, 0)
 	obj.domain = 0;
 	obj.bus = PCI_BUS_NUM(xdev->pdev->devfn);
+#else
+	obj.domain = xdev->pdev->slot->number;
+	obj.bus = xdev->pdev->bus->number;
+#endif
 	obj.dev = PCI_SLOT(xdev->pdev->devfn);
 	obj.func = PCI_FUNC(xdev->pdev->devfn);
 	if (copy_to_user(arg, &obj, sizeof(struct xdma_ioc_info)))

--- a/XDMA/linux-kernel/xdma/cdev_events.c
+++ b/XDMA/linux-kernel/xdma/cdev_events.c
@@ -59,7 +59,7 @@ static ssize_t char_events_read(struct file *file, char __user *buf,
 
 	/* wait_event_interruptible() was interrupted by a signal */
 	if (rv == -ERESTARTSYS)
-		return -ERESTARTSYS;
+		return -EAGAIN;
 
 	/* atomically decide which events are passed to the user */
 	spin_lock_irqsave(&user_irq->events_lock, flags);

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -36,13 +36,13 @@
 #include "xdma_thread.h"
 
 /* Module Parameters */
-unsigned int h2c_timeout = 10;
-module_param(h2c_timeout, uint, 0644);
-MODULE_PARM_DESC(h2c_timeout, "H2C sgdma timeout in seconds, default is 10 sec.");
+unsigned int h2c_timeout_ms = 10000;
+module_param(h2c_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(h2c_timeout_ms, "H2C sgdma timeout in milliseconds, default is 10 seconds.");
 
-unsigned int c2h_timeout = 10;
-module_param(c2h_timeout, uint, 0644);
-MODULE_PARM_DESC(c2h_timeout, "C2H sgdma timeout in seconds, default is 10 sec.");
+unsigned int c2h_timeout_ms = 10000;
+module_param(c2h_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(c2h_timeout_ms, "C2H sgdma timeout in milliseconds, default is 10 seconds.");
 
 extern struct kmem_cache *cdev_cache;
 static void char_sgdma_unmap_user_buf(struct xdma_io_cb *cb, bool write);
@@ -89,8 +89,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 		numbytes = xdma_xfer_completion((void *)cb, xdev,
 				engine->channel, cb->write, cb->ep_addr,
 				&cb->sgt, 0, 
-				cb->write ? h2c_timeout * 1000 :
-					    c2h_timeout * 1000);
+				cb->write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(cb, cb->write);
 
@@ -415,8 +414,7 @@ static ssize_t char_sgdma_read_write(struct file *file, const char __user *buf,
 		return rv;
 
 	res = xdma_xfer_submit(xdev, engine->channel, write, *pos, &cb.sgt,
-				0, write ? h2c_timeout * 1000 :
-					   c2h_timeout * 1000);
+				0, write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(&cb, write);
 
@@ -499,7 +497,7 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
-					0, h2c_timeout * 1000);
+					0, h2c_timeout_ms);
 	}
 
 	if (engine->cmplthp)
@@ -573,7 +571,7 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
-					0, c2h_timeout * 1000);
+					0, c2h_timeout_ms);
 	}
 
 	if (engine->cmplthp)
@@ -820,8 +818,7 @@ static int ioctl_do_aperture_dma(struct xdma_engine *engine, unsigned long arg,
 
 	io.error = 0;
 	res = xdma_xfer_aperture(engine, write, io.ep_addr, io.aperture,
-				&cb.sgt, 0, write ? h2c_timeout * 1000 :
-						c2h_timeout * 1000);
+				&cb.sgt, 0, write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(&cb, write);
 	if (res < 0)

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -433,7 +433,7 @@ static void engine_status_dump(struct xdma_engine *engine)
 		if ((v & XDMA_STAT_MAGIC_STOPPED))
 			len += sprintf(buf + len, "MAGIC_STOPPED ");
 		if ((v & XDMA_STAT_INVALID_LEN))
-			len += sprintf(buf + len, "INVLIAD_LEN ");
+			len += sprintf(buf + len, "INVALID_LEN ");
 		if ((v & XDMA_STAT_IDLE_STOPPED))
 			len += sprintf(buf + len, "IDLE_STOPPED ");
 		buf[len - 1] = ',';

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2343,12 +2343,7 @@ static void xdma_desc_link(struct xdma_desc *first, struct xdma_desc *second,
 /* xdma_desc_adjacent -- Set how many descriptors are adjacent to this one */
 static void xdma_desc_adjacent(struct xdma_desc *desc, u32 next_adjacent)
 {
-	/* remember reserved and control bits */
-	u32 control = le32_to_cpu(desc->control) & 0x0000f0ffUL;
-	/* merge adjacent and control field */
-	control |= 0xAD4B0000UL | (next_adjacent << 8);
-	/* write control and next_adjacent */
-	desc->control = cpu_to_le32(control);
+	desc->control = cpu_to_le32(le32_to_cpu(desc->control) | next_adjacent << 8);
 }
 
 /* xdma_desc_control -- Set complete control field of a descriptor. */

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -982,10 +982,10 @@ engine_service_final_transfer(struct xdma_engine *engine,
 				}
 			}
 
-			transfer->desc_cmpl += *pdesc_completed;
 			if (!(transfer->flags & XFER_FLAG_ST_C2H_EOP_RCVED)) {
 				return NULL;
 			}
+			transfer->desc_cmpl = *pdesc_completed;
 
 			/* mark transfer as successfully completed */
 			engine_service_shutdown(engine);
@@ -3627,8 +3627,8 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 				for (i = 0; i < xfer->desc_cmpl; i++)
 					done += result[i].length;
 
-				/* finish the whole request */
-				if (engine->eop_flush)
+				/* finish the whole request when EOP revcived */
+				if (engine->eop_flush && (xfer->flags & XFER_FLAG_ST_C2H_EOP_RCVED))
 					nents = 0;
 			} else
 				done += xfer->len;

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -3440,7 +3440,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 			transfer_dump(xfer);
 			sgt_dump(sgt);
 #endif
-			rv = -ERESTARTSYS;
+			rv = -ETIMEDOUT;
 			break;
 		}
 
@@ -3670,7 +3670,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			transfer_dump(xfer);
 			sgt_dump(sgt);
 #endif
-			rv = -ERESTARTSYS;
+			rv = -ETIMEDOUT;
 			break;
 		}
 
@@ -3801,7 +3801,7 @@ ssize_t xdma_xfer_completion(void *cb_hndl, void *dev_hndl, int channel,
 			transfer_dump(xfer);
 			sgt_dump(sgt);
 #endif
-			rv = -ERESTARTSYS;
+			rv = -ETIMEDOUT;
 			break;
 		}
 

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -413,7 +413,7 @@ static int engine_reg_dump(struct xdma_engine *engine)
 static void engine_status_dump(struct xdma_engine *engine)
 {
 	u32 v = engine->status;
-	char buffer[256];
+	char buffer[400];
 	char *buf = buffer;
 	int len = 0;
 

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1018,6 +1018,7 @@ engine_service_final_transfer(struct xdma_engine *engine,
 			WARN_ON(*pdesc_completed > transfer->desc_num);
 		}
 		/* mark transfer as successfully completed */
+		engine_service_shutdown(engine);
 		transfer->state = TRANSFER_STATE_COMPLETED;
 		transfer->desc_cmpl = transfer->desc_num;
 		/* add dequeued number of descriptors during this run */

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -417,7 +417,7 @@ static void engine_status_dump(struct xdma_engine *engine)
 	char *buf = buffer;
 	int len = 0;
 
-	len = sprintf(buf, "SG engine %s status: 0x%08x: ", engine->name, v);
+	len = sprintf(buf, "SG engine %.16s status: 0x%08x: ", engine->name, v);
 
 	if ((v & XDMA_STAT_BUSY))
 		len += sprintf(buf + len, "BUSY,");

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -231,7 +231,7 @@ static inline u32 build_u32(u32 hi, u32 lo)
 
 static inline u64 build_u64(u64 hi, u64 lo)
 {
-	return ((hi & 0xFFFFFFFULL) << 32) | (lo & 0xFFFFFFFFULL);
+	return ((hi & 0xFFFFFFFFULL) << 32) | (lo & 0xFFFFFFFFULL);
 }
 
 static void check_nonzero_interrupt_status(struct xdma_dev *xdev)

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -30,7 +30,7 @@
 #include "xdma_cdev.h"
 #include "version.h"
 
-#define DRV_MODULE_NAME		"xdma"
+#define DRV_MODULE_NAME		"xdma-chr"
 #define DRV_MODULE_DESC		"Xilinx XDMA Reference Driver"
 
 static char version[] =

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -173,13 +173,13 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	}
 
 	if (xpdev->h2c_channel_max > XDMA_CHANNEL_NUM_MAX) {
-		pr_err("Maximun H2C channel limit reached\n");
+		pr_err("Maximum H2C channel limit reached\n");
 		rv = -EINVAL;
 		goto err_out;
 	}
 
 	if (xpdev->c2h_channel_max > XDMA_CHANNEL_NUM_MAX) {
-		pr_err("Maximun C2H channel limit reached\n");
+		pr_err("Maximum C2H channel limit reached\n");
 		rv = -EINVAL;
 		goto err_out;
 	}

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -360,8 +360,8 @@ static int xdma_mod_init(void)
 
 	if (desc_blen_max > XDMA_DESC_BLEN_MAX)
 		desc_blen_max = XDMA_DESC_BLEN_MAX;
-	pr_info("desc_blen_max: 0x%x/%u, timeout: h2c %u c2h %u sec.\n",
-		desc_blen_max, desc_blen_max, h2c_timeout, c2h_timeout);
+	pr_info("desc_blen_max: 0x%x/%u, timeout: h2c %u c2h %u (ms)\n",
+		desc_blen_max, desc_blen_max, h2c_timeout_ms, c2h_timeout_ms);
 
 	rv = xdma_cdev_init();
 	if (rv < 0)

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -55,8 +55,8 @@
 #define MAGIC_BITSTREAM 0xBBBBBBBBUL
 
 extern unsigned int desc_blen_max;
-extern unsigned int h2c_timeout;
-extern unsigned int c2h_timeout;
+extern unsigned int h2c_timeout_ms;
+extern unsigned int c2h_timeout_ms;
 
 struct xdma_cdev {
 	unsigned long magic;		/* structure ID for sanity checks */


### PR DESCRIPTION
In creating an 8 byte word out of two 8 byte words the top 4 bits of the hi part get blanked out due to a typo, a forgottren F.