### PR TITLE
fix: use ccflags-y instead of EXTRA_CFLAGS

### DIFF
--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -20,14 +20,14 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma-chr
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
+ccflags-y := -I$(topdir)/include $(XVC_FLAGS)
 ifeq ($(DEBUG),1)
-	EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
+	ccflags-y += -D__LIBXDMA_DEBUG__
 endif
 ifneq ($(config_bar_num),)
-	EXTRA_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
+	ccflags-y += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
 endif
-#EXTRA_CFLAGS += -DINTERNAL_TESTING
+#ccflags-y += -DINTERNAL_TESTING
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o


### PR DESCRIPTION
`EXTRA_CFLAGS` had been deprecated in favor of `ccflags-y` for decades - with recent kernels, the support for `EXTRA_CFLAGS` has now been dropped. (AFAICS, the breaking change was with 6.15 upstream, but there may be newer kernels in circulation which still support it due to a compatibility patch).
On my Ubuntu 24.04 system with `#35~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue May 26 19:30:42 UTC 2` this driver wouldn't build anymore.

This PR changes `EXTRA_CFLAGS` for `ccflags-y` to make it build with new kernels; since `EXTRA_CFLAGS` had been deprecated for so long, it should also still build with (reasonably) older kernels.